### PR TITLE
Updated the DataSourceOVF.py to allow network interfaces to be configured

### DIFF
--- a/cloudinit/distros/rhel.py
+++ b/cloudinit/distros/rhel.py
@@ -69,6 +69,7 @@ class Distro(distros.Distro):
         # Make the intermediate format as the rhel format...
         nameservers = []
         searchservers = []
+        local_domain = None
         dev_names = entries.keys()
         for (dev, info) in entries.iteritems():
             net_fn = self.network_script_tpl % (dev)
@@ -87,9 +88,11 @@ class Distro(distros.Distro):
                 nameservers.extend(info['dns-nameservers'])
             if 'dns-search' in info:
                 searchservers.extend(info['dns-search'])
-        if nameservers or searchservers:
+            if 'dns-domain' in info:
+                local_domain = info['dns-domain']
+        if nameservers or searchservers or local_domain:
             rhel_util.update_resolve_conf_file(self.resolve_conf_fn,
-                                               nameservers, searchservers)
+                                               nameservers, searchservers, local_domain)
         if dev_names:
             net_cfg = {
                 'NETWORKING': _make_sysconfig_bool(True),

--- a/cloudinit/distros/rhel_util.py
+++ b/cloudinit/distros/rhel_util.py
@@ -95,6 +95,9 @@ def translate_network(settings):
         # Name server search info provided??
         if 'dns-search' in info:
             iface_info['dns-search'] = info['dns-search'].split()
+        # Local Domain provided ??
+        if 'dns-domain' in info:
+            iface_info['dns-domain'] = info['dns-domain']
         # Is any mac address spoofing going on??
         if 'hwaddress' in info:
             hw_info = info['hwaddress'].lower().strip()
@@ -153,7 +156,7 @@ def read_sysconfig_file(fn):
 
 
 # Helper function to update RHEL/SUSE /etc/resolv.conf
-def update_resolve_conf_file(fn, dns_servers, search_servers):
+def update_resolve_conf_file(fn, dns_servers, search_servers, local_domain):
     try:
         r_conf = ResolvConf(util.load_file(fn))
         r_conf.parse()
@@ -174,4 +177,6 @@ def update_resolve_conf_file(fn, dns_servers, search_servers):
                 r_conf.add_search_domain(s)
             except ValueError:
                 util.logexc(LOG, "Failed at adding search domain %s", s)
+    if local_domain is not None:
+            r_conf.local_domain = local_domain
     util.write_file(fn, str(r_conf), 0644)

--- a/cloudinit/distros/sles.py
+++ b/cloudinit/distros/sles.py
@@ -90,7 +90,7 @@ class Distro(distros.Distro):
                 searchservers.extend(info['dns-search'])
         if nameservers or searchservers:
             rhel_util.update_resolve_conf_file(self.resolve_conf_fn,
-                                               nameservers, searchservers)
+                                               nameservers, searchservers, None)
         return dev_names
 
     def apply_locale(self, locale, out_fn=None):


### PR DESCRIPTION
by properties in the OVF environment.  This re-uses functions in distros
folder to configure the interfaces.

N.B the functions currently expect ubuntu style interface definitions i.e.

`network-interfaces: |
  iface eth0 inet static
  address 192.168.1.10
  network 192.168.1.0
  netmask 255.255.255.0
  broadcast 192.168.1.255
  gateway 192.168.1.254
  dns-nameservers 10.20.10.110 10.20.10.113
  dns-search mydomain.com
  dns-domain mydomain.com
  iface eth1 inet static
  address 192.168.1.11
  netmask 255.255.255.0`

This isn't easy to represent as a single property, so instead indvidual properties
with the correct format define an interface.  i.e. to define an interface add a property

`network.interface.0 = eth0`

to configure that interface add the following properties

`network.eth0.address = 192.168.1.10
network.eth0.netmask = 255.255.0.0
network.eth0.gateway = 192.168.1.255
network.eth0.dns-nameservers = 10.20.10.110 10.20.10.113`

Multiple interfaces maybe defined.  N.B when using a vApp with multiple VMs the properties maybe
qualified by the entity id.  In this case the ovf environment generated would actually look like:

`network.eth0.address.mymachineid
network.eth0.netmask.mymachineid`

The code will check if the entity id is set, and strip it off, so either format will work.

1) Example of generated ovf environment with entitiy id

`<?xml version="1.0" encoding="UTF-8"?>
<Environment
     xmlns="http://schemas.dmtf.org/ovf/environment/1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:oe="http://schemas.dmtf.org/ovf/environment/1"
     xmlns:ve="http://www.vmware.com/schema/ovfenv"
     oe:id="machine-01"
     ve:vCenterId="vm-16300">
   <PlatformSection>
      <Kind>VMware ESXi</Kind>
      <Version>5.1.0</Version>
      <Vendor>VMware, Inc.</Vendor>
      <Locale>en</Locale>
   </PlatformSection>
   <PropertySection>
         <Property oe:key="hostname.machine-01" oe:value="dl360g8-06-vm01"/>
         <Property oe:key="instance-id.machine-01" oe:value="0001"/>
         <Property oe:key="network.eth0.address.machine-01" oe:value="10.20.50.211"/>
         <Property oe:key="network.eth0.dns-domain.machine-01" oe:value="mydomain.com"/>
         <Property oe:key="network.eth0.dns-nameservers.machine-01" oe:value="10.20.10.110 10.20.10.113"/>
         <Property oe:key="network.eth0.dns-search.machine-01" oe:value="mydomain.com"/>
         <Property oe:key="network.eth0.gateway.machine-01" oe:value="10.20.50.1"/>
         <Property oe:key="network.eth0.netmask.machine-01" oe:value="255.255.255.0"/>
         <Property oe:key="network.eth1.address.machine-01" oe:value="192.168.100.211"/>
         <Property oe:key="network.eth1.netmask.machine-01" oe:value="255.255.0.0"/>
         <Property oe:key="network.interface.0.machine-01" oe:value="eth0"/>
         <Property oe:key="network.interface.1.machine-01" oe:value="eth1"/>
         <Property oe:key="password.machine-01" oe:value="cloudpassword"/>
   </PropertySection>
</Environment>`

2) Example of generated ovf environment without the entity id

`<?xml version="1.0" encoding="UTF-8"?>
<Environment
     xmlns="http://schemas.dmtf.org/ovf/environment/1"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xmlns:oe="http://schemas.dmtf.org/ovf/environment/1"
     xmlns:ve="http://www.vmware.com/schema/ovfenv"
     oe:id=""
     ve:vCenterId="vm-16300">
   <PlatformSection>
      <Kind>VMware ESXi</Kind>
      <Version>5.1.0</Version>
      <Vendor>VMware, Inc.</Vendor>
      <Locale>en</Locale>
   </PlatformSection>
   <PropertySection>
         <Property oe:key="hostname" oe:value="dl360g8-06-vm01"/>
         <Property oe:key="instance-id" oe:value="0001"/>
         <Property oe:key="network.eth0.address" oe:value="10.20.50.211"/>
         <Property oe:key="network.eth0.dns-domain" oe:value="mydomain.com"/>
         <Property oe:key="network.eth0.dns-nameservers" oe:value="10.20.10.110 10.20.10.113"/>
         <Property oe:key="network.eth0.dns-search" oe:value="mydomain.com"/>
         <Property oe:key="network.eth0.gateway" oe:value="10.20.50.1"/>
         <Property oe:key="network.eth0.netmask" oe:value="255.255.255.0"/>
         <Property oe:key="network.eth1.address" oe:value="192.168.100.211"/>
         <Property oe:key="network.eth1.netmask" oe:value="255.255.0.0"/>
         <Property oe:key="network.interface.0" oe:value="eth0"/>
         <Property oe:key="network.interface.1" oe:value="eth1"/>
         <Property oe:key="password" oe:value="cloudpassword"/>
   </PropertySection>
</Environment>`

Finally the corropsonding property section of the ovf file itself

```
  `<ProductSection xmlns="http://schemas.dmtf.org/ovf/envelope/1" xmlns:ovf="http://schemas.dmtf.org/ovf/envelope/1" ovf:instance="machinie-01">
    <Info>Information about the installed software</Info>
    <Property ovf:key="network.interface.0" ovf:type="string" ovf:userConfigurable="true" ovf:value="eth0">
      <Label>network.interface</Label>
    </Property>
    <Property ovf:key="network.eth0.address" ovf:type="string" ovf:userConfigurable="true" vmw:qualifiers="Ip">
      <Label>network.eth0.address</Label>
    </Property>
  <Property ovf:key="network.eth0.netmask" ovf:type="string" ovf:userConfigurable="true">
    <Label>Netmask 1</Label>
    <Description>The Netmask of interface 1</Description>
  </Property>
    ...
    ...
 </ProductSection>`
```

It looks like the entity id is only set when the OVF is a vApp.  If it is a single OVF, it will not be used.
