### PR TITLE
Fix bug when counting disk device childs

### DIFF
--- a/cloudinit/config/cc_disk_setup.py
+++ b/cloudinit/config/cc_disk_setup.py
@@ -303,8 +303,8 @@ def is_disk_used(device):
 
     # If the child count is higher 1, then there are child nodes
     # such as partition or device mapper nodes
-    use_count = [x for x in enumerate_disk(device)]
-    if len(use_count.splitlines()) > 1:
+    use_count = enumerate_disk(device)
+    if len(use_count) > 1:
         return True
 
     # If we see a file system, then its used


### PR DESCRIPTION
Function enumerate_disk returns an array of dicts. Also I believe that
in this case iterating the returned array is not necessary because is
always going to return the same array.

Just getting the len of the array should be enough to know if the device
has childs.