### PR TITLE
Fix typo in default keys for phone_home

### DIFF
--- a/cloudinit/config/cc_phone_home.py
+++ b/cloudinit/config/cc_phone_home.py
@@ -31,7 +31,7 @@ POST_LIST_ALL = [
     'pub_key_ecdsa',
     'instance_id',
     'hostname',
-    'fdqn'
+    'fqdn'
 ]
 
 


### PR DESCRIPTION
This should be fqdn, not fdqn.